### PR TITLE
Small follow-up tweaks to COSE_Sign_Args

### DIFF
--- a/draft-lundberg-cose-two-party-signing-algs.md
+++ b/draft-lundberg-cose-two-party-signing-algs.md
@@ -242,17 +242,17 @@ two additional arguments `kh` and `info` are needed in `ARKG-Derive-Private-Key`
 
 While such additional arguments are simple to provide to the API of the signing procedure in a single-party context,
 in a split signing context these additional arguments also need to be conveyed from the _digester_ to the _signer_.
-For this purpose, we define a new COSE structure COSE_Sign_Args for "COSE signing arguments".
+For this purpose, we define a new COSE structure `COSE_Sign_Args` for "COSE signing arguments".
 This enables defining a unified, algorithm-agnostic protocol between the _digester_ and the _signer_,
 rather than requiring a distinct protocol for each signature algorithm for the sake of conveying algorithm-specific parameters.
 
-COSE_Sign_Args is built on a CBOR map.
-The set of common parameters that can appear in a COSE_Sign_Args
+`COSE_Sign_Args` is built on a CBOR map.
+The set of common parameters that can appear in a `COSE_Sign_Args`
 can be found in the IANA "COSE Signing Arguments Common Parameters" registry (TODO).
 Additional parameters defined for specific signing algorithms
 can be found in the IANA "COSE Signing Arguments Algorithm Parameters" registry (TODO).
 
-The CDDL grammar describing COSE_Sign_Args, using the CDDL fragment defined in {{Section 1.5 of RFC9052}}, is:
+The CDDL grammar describing `COSE_Sign_Args`, using the CDDL fragment defined in {{Section 1.5 of RFC9052}}, is:
 
 ~~~cddl
 COSE_Sign_Args = {
@@ -279,7 +279,7 @@ This document defines a set of common parameters for a COSE Signing Arguments ob
 
   "alg" MAY be omitted when the algorithm to use is implicit from context.
 
-Definitions of COSE algorithms MAY define additional algorithm-specific parameters for COSE_Sign_Args.
+Definitions of COSE algorithms MAY define additional algorithm-specific parameters for `COSE_Sign_Args`.
 
 The following CDDL example conveys additional arguments for signing data
 using the ESP256-split algorithm (see {{ecdsa-split}})

--- a/draft-lundberg-cose-two-party-signing-algs.md
+++ b/draft-lundberg-cose-two-party-signing-algs.md
@@ -235,7 +235,7 @@ The following algorithm identifiers are defined:
 # COSE Signing Arguments {#cose-sign-args}
 
 While many signature algorithms take the private key and data to be signed as the only two parameters,
-some signature algorithms use additional parameters to the signature generation.
+some signature algorithms have additional parameters that must also be set.
 For example,
 to sign using a key derived by ARKG [I-D.bradleylundberg-ARKG],
 two additional arguments `kh` and `info` are needed in `ARKG-Derive-Private-Key` to derive the signing private key.

--- a/draft-lundberg-cose-two-party-signing-algs.md
+++ b/draft-lundberg-cose-two-party-signing-algs.md
@@ -272,12 +272,9 @@ This document defines a set of common parameters for a COSE Signing Arguments ob
 | ---- | ----- | ---------- | --------------- | ----------- |
 | alg  | 3     | tstr / int | COSE Algorithms | Signing algorithm to use |
 
-- alg: This parameter is used to identify the signing algorithm to use.
-  If this parameter is present,
-  the signer MUST verify that this algorithm matches any key usage restrictions set on the key to be used.
+- alg: This parameter identifies the signing algorithm the additional arguments apply to.
+  The signer MUST verify that this algorithm matches any key usage restrictions set on the key to be used.
   If the algorithms do not match, then the signature operation MUST be aborted with an error.
-
-  "alg" MAY be omitted when the algorithm to use is implicit from context.
 
 Definitions of COSE algorithms MAY define additional algorithm-specific parameters for `COSE_Sign_Args`.
 


### PR DESCRIPTION
- [Minor rewording](https://github.com/YubicoLabs/cose-two-party-signing-algs-rfc/commit/0f60aab7776cd670880650b3e6931ffe43766ef2)
- Format COSE_Sign_Args as monospace
- `alg` must not be omitted from COSE_Sign_Args